### PR TITLE
Add explanation to readme to avoid dependency issues when use engine as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ assemblyMergeStrategy in assembly := {
 }
 ```
 
+If you get this kind of exception when run engine's code which is making use of bblfsh,
+
+    java.lang.NoSuchMethodError: com.google.common.util.concurrent.MoreExecutors.directExecutor()Ljava/util/concurrent/Executor;
+
+ you must add these lines to your `build.sbt`
+
+ ```scala
+ assemblyShadeRules in assembly := Seq(
+  ShadeRule.rename("com.google.common.**" -> "com.google.shadedcommon.@1").inAll,
+  ShadeRule.rename("io.netty.**" -> "io.shadednetty.@1").inAll
+)
+ ```
+
 ## pyspark
 
 ### Local mode


### PR DESCRIPTION
I got this exception when using engine as a dependency in another application and the code has to connect to bblfsh:

```scala
java.lang.NoSuchMethodError: com.google.common.util.concurrent.MoreExecutors.directExecutor()Ljava/util/concurrent/Executor;
	at io.grpc.internal.ClientCallImpl.<init>(ClientCallImpl.java:104)
	at io.grpc.internal.ManagedChannelImpl$RealChannel.newCall(ManagedChannelImpl.java:554)
	at io.grpc.internal.ManagedChannelImpl.newCall(ManagedChannelImpl.java:533)
	at gopkg.in.bblfsh.sdk.v1.protocol.generated.ProtocolServiceGrpc$ProtocolServiceBlockingStub.parse(ProtocolServiceGrpc.scala:50)
	at org.bblfsh.client.BblfshClient.parse(BblfshClient.scala:29)
	at tech.sourced.engine.util.Bblfsh$.extractUAST(Bblfsh.scala:80)
	at tech.sourced.engine.udf.ExtractUASTsUDF$class.extractUASTs(ExtractUASTsUDF.scala:17)
	at tech.sourced.engine.udf.ExtractUASTsWithLangUDF$.extractUASTs(ExtractUASTsUDF.scala:59)
	at tech.sourced.engine.udf.ExtractUASTsWithLangUDF$$anonfun$function$2.apply(ExtractUASTsUDF.scala:66)
	at tech.sourced.engine.udf.ExtractUASTsWithLangUDF$$anonfun$function$2.apply(ExtractUASTsUDF.scala:65)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIterator.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
	at org.apache.spark.sql.execution.WholeStageCodegenExec$$anonfun$8$$anon$1.hasNext(WholeStageCodegenExec.scala:395)
	at org.apache.spark.sql.execution.columnar.InMemoryRelation$$anonfun$1$$anon$1.hasNext(InMemoryRelation.scala:133)
	at org.apache.spark.storage.memory.MemoryStore.putIteratorAsValues(MemoryStore.scala:215)
	at org.apache.spark.storage.BlockManager$$anonfun$doPutIterator$1.apply(BlockManager.scala:1038)
	at org.apache.spark.storage.BlockManager$$anonfun$doPutIterator$1.apply(BlockManager.scala:1029)
	at org.apache.spark.storage.BlockManager.doPut(BlockManager.scala:969)
	at org.apache.spark.storage.BlockManager.doPutIterator(BlockManager.scala:1029)
	at org.apache.spark.storage.BlockManager.getOrElseUpdate(BlockManager.scala:760)
	at org.apache.spark.rdd.RDD.getOrCompute(RDD.scala:334)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:285)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:38)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:323)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:287)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:38)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:323)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:287)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:38)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:323)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:287)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:96)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:53)
	at org.apache.spark.scheduler.Task.run(Task.scala:108)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:335)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

Adding these lines (they are in engine's `build.sbt` too) to the `build.sbt` fix the problem:
```
assemblyShadeRules in assembly := Seq(
  ShadeRule.rename("com.google.common.**" -> "com.google.shadedcommon.@1").inAll,
  ShadeRule.rename("io.netty.**" -> "io.shadednetty.@1").inAll
)
```

Do you think we should add it to the `README`?